### PR TITLE
Fixed following issues:

### DIFF
--- a/generative/losses/adversarial_loss.py
+++ b/generative/losses/adversarial_loss.py
@@ -118,7 +118,7 @@ class PatchAdversarialLoss(_Loss):
 
         """
 
-        if not for_discriminator:
+        if not for_discriminator and not target_is_real:
             target_is_real = True  # With generator, we always want this to be true!
             warnings.warn(
                 "Variable target_is_real has been set to False, but for_discriminator is set"


### PR DESCRIPTION
- Bug in adversarial_loss.py (if target_is_real = False AND if not for_discriminator, Warning should be triggered)
- Some default types for PatchGAN and MultiScalePathGAN were missing
- Assertion of minimum image size required for num_d and num_layers_d moved from PatchGAN discriminator to MultiScalePatchGAN discriminator