### PR TITLE
Addition of is_fake_3d setting condition to error in PerceptualLoss

### DIFF
--- a/generative/losses/perceptual.py
+++ b/generative/losses/perceptual.py
@@ -46,8 +46,10 @@ class PerceptualLoss(nn.Module):
             raise NotImplementedError("Perceptual loss is implemented only in 2D and 3D.")
 
         if (spatial_dims == 2 or is_fake_3d) and "medicalnet_" in network_type:
-            raise ValueError("MedicalNet networks are only compatible with ``spatial_dims=3``."
-                             "Argument is_fake_3d must be set to False.")
+            raise ValueError(
+                "MedicalNet networks are only compatible with ``spatial_dims=3``."
+                "Argument is_fake_3d must be set to False."
+            )
 
         self.spatial_dims = spatial_dims
         if spatial_dims == 3 and is_fake_3d is False:


### PR DESCRIPTION
Flag is_fake_3d cannot be True is medicalnet is used for Perceptual Loss. This was unaccounted for in the ValueError set in the __init__ to force users to check these values. 
>> Changed Value Error