### PR TITLE
Initialise inference_timesteps to train_timesteps

### DIFF
--- a/generative/networks/schedulers/ddim.py
+++ b/generative/networks/schedulers/ddim.py
@@ -103,12 +103,14 @@ class DDIMScheduler(nn.Module):
         # standard deviation of the initial noise distribution
         self.init_noise_sigma = 1.0
 
-        # setable values
-        self.num_inference_steps = None
+
         self.timesteps = torch.from_numpy(np.arange(0, num_train_timesteps)[::-1].astype(np.int64))
 
         self.clip_sample = clip_sample
         self.steps_offset = steps_offset
+
+        # default the number of inference timesteps to the number of train steps
+        self.set_timesteps(num_train_timesteps)
 
     def set_timesteps(self, num_inference_steps: int, device: str | torch.device | None = None) -> None:
         """

--- a/generative/networks/schedulers/pndm.py
+++ b/generative/networks/schedulers/pndm.py
@@ -117,13 +117,11 @@ class PNDMScheduler(nn.Module):
         self.cur_sample = None
         self.ets = []
 
-        # settable values
-        self.num_inference_steps = None
-        self._timesteps = np.arange(0, num_train_timesteps)[::-1].copy()
-        self.prk_timesteps = torch.Tensor([])
-        self.plms_timesteps = torch.Tensor([])
-        self.timesteps = torch.Tensor([])
 
+        self._timesteps = np.arange(0, num_train_timesteps)[::-1].copy()
+
+        # default the number of inference timesteps to the number of train steps
+        self.set_timesteps(num_train_timesteps)
     def set_timesteps(self, num_inference_steps: int, device: str | torch.device | None = None) -> None:
         """
         Sets the discrete timesteps used for the diffusion chain. Supporting function to be run before inference.

--- a/tests/test_scheduler_pndm.py
+++ b/tests/test_scheduler_pndm.py
@@ -39,13 +39,6 @@ class TestDDPMScheduler(unittest.TestCase):
         noisy = scheduler.add_noise(original_samples=original_sample, noise=noise, timesteps=timesteps)
         self.assertEqual(noisy.shape, expected_shape)
 
-    @parameterized.expand(TEST_CASES)
-    def test_error_if_timesteps_not_set(self, input_param, input_shape, expected_shape):
-        scheduler = PNDMScheduler(**input_param)
-        with self.assertRaises(ValueError):
-            model_output = torch.randn(input_shape)
-            sample = torch.randn(input_shape)
-            scheduler.step(model_output=model_output, timestep=500, sample=sample)
 
     @parameterized.expand(TEST_CASES)
     def test_step_shape(self, input_param, input_shape, expected_shape):


### PR DESCRIPTION
Fixes #217, where the PNDM and DDIM schedulers show different behaviour if they are used for stepping without calling `set_timesteps` first. @ericspod suggests objects should be immediately useable on creation, without extra methods needing to be called, so I've changed the default so the number of inference timesteps is set to the number of train timesteps during initalisation. 