### PR TITLE
Fixes transformer max_sequence_length training/inference

### DIFF
--- a/tests/test_vqvaetransformer_inferer.py
+++ b/tests/test_vqvaetransformer_inferer.py
@@ -104,7 +104,7 @@ class TestVQVAETransformerInferer(unittest.TestCase):
         stage_1 = VQVAE(**stage_1_params)
         max_seq_len = 3
         stage_2_params_shorter = {k: v for k, v in stage_2_params.items()}
-        stage_2_params_shorter['max_seq_len'] = max_seq_len
+        stage_2_params_shorter["max_seq_len"] = max_seq_len
         stage_2 = DecoderOnlyTransformer(**stage_2_params_shorter)
         ordering = Ordering(**ordering_params)
 
@@ -234,7 +234,7 @@ class TestVQVAETransformerInferer(unittest.TestCase):
         stage_1 = VQVAE(**stage_1_params)
         max_seq_len = 3
         stage_2_params_shorter = {k: v for k, v in stage_2_params.items()}
-        stage_2_params_shorter['max_seq_len'] = max_seq_len
+        stage_2_params_shorter["max_seq_len"] = max_seq_len
         stage_2 = DecoderOnlyTransformer(**stage_2_params_shorter)
         ordering = Ordering(**ordering_params)
 
@@ -251,6 +251,7 @@ class TestVQVAETransformerInferer(unittest.TestCase):
             inputs=input, vqvae_model=stage_1, transformer_model=stage_2, ordering=ordering
         )
         self.assertEqual(likelihood.shape, latent_shape)
+
     @parameterized.expand(TEST_CASES)
     def test_get_likelihood_resampling(
         self, stage_1_params, stage_2_params, ordering_params, input_shape, logits_shape, latent_shape


### PR DESCRIPTION
Fixes #281 

The only issue is that likelihood inference is slow when the sequence length exceeds the transformer's max sequence length; as the transformer doesn't do any caching of previous calculations during the for loop.