### PR TITLE
389 add torchvision resnet50 support

### DIFF
--- a/generative/losses/perceptual.py
+++ b/generative/losses/perceptual.py
@@ -25,8 +25,8 @@ class PerceptualLoss(nn.Module):
     features as a perceptual metric." https://arxiv.org/abs/1801.03924 ; RadImagenet from Mei, et al. "RadImageNet: An
     Open Radiologic Deep Learning Research Dataset for Effective Transfer Learning"
     https://pubs.rsna.org/doi/full/10.1148/ryai.210315 ; MedicalNet from Chen et al. "Med3D: Transfer Learning for
-    3D Medical Image Analysis" https://arxiv.org/abs/1904.00625 and ResNet50 from Torchvision:
-    https://pytorch.org/vision/main/models/generated/torchvision.models.resnet50.html.
+    3D Medical Image Analysis" https://arxiv.org/abs/1904.00625 ;
+    and ResNet50 from Torchvision: https://pytorch.org/vision/main/models/generated/torchvision.models.resnet50.html .
 
     The fake 3D implementation is based on a 2.5D approach where we calculate the 2D perceptual on slices from the
     three axis.

--- a/tests/test_perceptual_loss.py
+++ b/tests/test_perceptual_loss.py
@@ -14,9 +14,8 @@ from __future__ import annotations
 import unittest
 
 import torch
-from parameterized import parameterized
-
 from generative.losses import PerceptualLoss
+from parameterized import parameterized
 
 TEST_CASES = [
     [{"spatial_dims": 2, "network_type": "squeeze"}, (2, 1, 64, 64), (2, 1, 64, 64)],
@@ -34,6 +33,11 @@ TEST_CASES = [
     ],
     [
         {"spatial_dims": 3, "network_type": "medicalnet_resnet10_23datasets", "is_fake_3d": False},
+        (2, 1, 64, 64, 64),
+        (2, 1, 64, 64, 64),
+    ],
+    [
+        {"spatial_dims": 3, "network_type": "resnet50", "is_fake_3d": True, "pretrained": True, "fake_3d_ratio": 0.2},
         (2, 1, 64, 64, 64),
         (2, 1, 64, 64, 64),
     ],


### PR DESCRIPTION
Fixes #389 

This PR is used to enable torchvision's version of resnet50 on `PerceptualLoss`.
Users can also determine which pretrained weights is used.