### PR TITLE
475 add different downsampling methods to patch gan discriminator

### DIFF
--- a/generative/networks/nets/patchgan_discriminator.py
+++ b/generative/networks/nets/patchgan_discriminator.py
@@ -81,14 +81,15 @@ class MultiScalePatchDiscriminator(nn.Sequential):
             len(self.num_layers_d) == self.num_d
         ), f"MultiScalePatchDiscriminator: num_d {num_d} must match the number of num_layers_d. {num_layers_d}"
 
+        self.padding = tuple([int((kernel_size - 1) / 2)] * spatial_dims)
+
         if pooling_method is None:
             pool = None
         else:
             pool = get_pool_layer(
-                (pooling_method, {"kernel_size": kernel_size, "stride": 2}), spatial_dims=spatial_dims
+                (pooling_method, {"kernel_size": kernel_size, "stride": 2, 'padding': self.padding}), spatial_dims=spatial_dims
             )
         self.num_channels = num_channels
-        self.padding = tuple([int((kernel_size - 1) / 2)] * spatial_dims)
         for i_ in range(self.num_d):
             num_layers_d_i = self.num_layers_d[i_]
             output_size = float(minimum_size_im) / (2**num_layers_d_i)

--- a/generative/networks/nets/patchgan_discriminator.py
+++ b/generative/networks/nets/patchgan_discriminator.py
@@ -38,6 +38,8 @@ class MultiScalePatchDiscriminator(nn.Sequential):
         spatial_dims: number of spatial dimensions (1D, 2D etc.)
         num_channels: number of filters in the first convolutional layer (double of the value is taken from then on)
         in_channels: number of input channels
+        pooling_method: pooling method to be applied before each discriminator after the first.
+            If None, the number of layers is multiplied by the number of discriminators.
         out_channels: number of output channels in each discriminator
         kernel_size: kernel size of the convolution layers
         activation: activation layer type
@@ -52,10 +54,11 @@ class MultiScalePatchDiscriminator(nn.Sequential):
     def __init__(
         self,
         num_d: int,
-        num_layers_d: int,
+        num_layers_d: int | list[int],
         spatial_dims: int,
         num_channels: int,
         in_channels: int,
+        pooling_method: str = None,
         out_channels: int = 1,
         kernel_size: int = 4,
         activation: str | tuple = (Act.LEAKYRELU, {"negative_slope": 0.2}),
@@ -67,31 +70,71 @@ class MultiScalePatchDiscriminator(nn.Sequential):
     ) -> None:
         super().__init__()
         self.num_d = num_d
+        if isinstance(num_layers_d, int) and pooling_method is None:
+            # if pooling_method is None, calculate the number of layers for each discriminator by multiplying by the number of discriminators
+            num_layers_d = [num_layers_d * i for i in range(1, num_d + 1)]
+        elif isinstance(num_layers_d, int) and pooling_method is not None:
+            # if pooling_method is not None, the number of layers is the same for all discriminators
+            num_layers_d = [num_layers_d] * num_d
         self.num_layers_d = num_layers_d
+        assert (
+            len(self.num_layers_d) == self.num_d
+        ), f"MultiScalePatchDiscriminator: num_d {num_d} must match the number of num_layers_d. {num_layers_d}"
+
+        if pooling_method is None:
+            self.pool = None
+        elif pooling_method.lower() == "max":
+            self.pool = nn.MaxPool2d(kernel_size=kernel_size, stride=2)
+        elif pooling_method.lower() == "avg":
+            self.pool = nn.AvgPool2d(kernel_size=kernel_size, stride=2)
+        else:
+            raise ValueError(f"MultiScalePatchDiscriminator: Pooling method {pooling_method} is not supported.")
+        print(
+            f"Initialising MultiScalePatchDiscriminator with {self.num_d} discriminators, {self.num_layers_d} layers and pooling method {self.pool.__class__.__name__}."
+        )
         self.num_channels = num_channels
         self.padding = tuple([int((kernel_size - 1) / 2)] * spatial_dims)
         for i_ in range(self.num_d):
-            num_layers_d_i = self.num_layers_d * (i_ + 1)
+            num_layers_d_i = self.num_layers_d[i_]
             output_size = float(minimum_size_im) / (2**num_layers_d_i)
             if output_size < 1:
                 raise AssertionError(
                     "Your image size is too small to take in up to %d discriminators with num_layers = %d."
                     "Please reduce num_layers, reduce num_D or enter bigger images." % (i_, num_layers_d_i)
                 )
-            subnet_d = PatchDiscriminator(
-                spatial_dims=spatial_dims,
-                num_channels=self.num_channels,
-                in_channels=in_channels,
-                out_channels=out_channels,
-                num_layers_d=num_layers_d_i,
-                kernel_size=kernel_size,
-                activation=activation,
-                norm=norm,
-                bias=bias,
-                padding=self.padding,
-                dropout=dropout,
-                last_conv_kernel_size=last_conv_kernel_size,
-            )
+            if i_ == 0 or self.pool is None:
+                subnet_d = PatchDiscriminator(
+                    spatial_dims=spatial_dims,
+                    num_channels=self.num_channels,
+                    in_channels=in_channels,
+                    out_channels=out_channels,
+                    num_layers_d=num_layers_d_i,
+                    kernel_size=kernel_size,
+                    activation=activation,
+                    norm=norm,
+                    bias=bias,
+                    padding=self.padding,
+                    dropout=dropout,
+                    last_conv_kernel_size=last_conv_kernel_size,
+                )
+            else:
+                subnet_d = nn.Sequential(
+                    *[self.pool] * i_,
+                    PatchDiscriminator(
+                        spatial_dims=spatial_dims,
+                        num_channels=self.num_channels,
+                        in_channels=in_channels,
+                        out_channels=out_channels,
+                        num_layers_d=num_layers_d_i,
+                        kernel_size=kernel_size,
+                        activation=activation,
+                        norm=norm,
+                        bias=bias,
+                        padding=self.padding,
+                        dropout=dropout,
+                        last_conv_kernel_size=last_conv_kernel_size,
+                    ),
+                )
 
             self.add_module("discriminator_%d" % i_, subnet_d)
 

--- a/generative/networks/nets/patchgan_discriminator.py
+++ b/generative/networks/nets/patchgan_discriminator.py
@@ -17,7 +17,7 @@ from collections.abc import Sequence
 import torch
 import torch.nn as nn
 from monai.networks.blocks import Convolution
-from monai.networks.layers import (Act, get_pool_layer)
+from monai.networks.layers import Act, get_pool_layer
 
 
 class MultiScalePatchDiscriminator(nn.Sequential):
@@ -84,7 +84,9 @@ class MultiScalePatchDiscriminator(nn.Sequential):
         if pooling_method is None:
             pool = None
         else:
-            pool = get_pool_layer((pooling_method, {"kernel_size": kernel_size, "stride": 2}), spatial_dims=spatial_dims)
+            pool = get_pool_layer(
+                (pooling_method, {"kernel_size": kernel_size, "stride": 2}), spatial_dims=spatial_dims
+            )
         print(
             f"Initialising {spatial_dims}D MultiScalePatchDiscriminator with {self.num_d} discriminators, {self.num_layers_d} layers and pooling method {pool.__class__.__name__}."
         )

--- a/generative/networks/nets/patchgan_discriminator.py
+++ b/generative/networks/nets/patchgan_discriminator.py
@@ -87,9 +87,6 @@ class MultiScalePatchDiscriminator(nn.Sequential):
             pool = get_pool_layer(
                 (pooling_method, {"kernel_size": kernel_size, "stride": 2}), spatial_dims=spatial_dims
             )
-        print(
-            f"Initialising {spatial_dims}D MultiScalePatchDiscriminator with {self.num_d} discriminators, {self.num_layers_d} layers and pooling method {pool.__class__.__name__}."
-        )
         self.num_channels = num_channels
         self.padding = tuple([int((kernel_size - 1) / 2)] * spatial_dims)
         for i_ in range(self.num_d):

--- a/tests/test_patch_gan.py
+++ b/tests/test_patch_gan.py
@@ -58,6 +58,65 @@ TEST_3D = [
     [(1, 1, 32, 64, 32), (1, 1, 4, 8, 4)],
     [4, 7],
 ]
+TEST_3D_POOL = [
+{
+        "num_d": 2,
+        "num_layers_d": 3,
+        "spatial_dims": 3,
+        "num_channels": 8,
+        "in_channels": 3,
+        "out_channels": 1,
+        "kernel_size": 3,
+        "pooling_method": "max",
+        "activation": "LEAKYRELU",
+        "norm": "instance",
+        "bias": False,
+        "dropout": 0.1,
+        "minimum_size_im": 256,
+    },
+    torch.rand([1, 3, 256, 512, 256]),
+    [(1, 1, 32, 64, 32), (1, 1, 16, 32, 16)],
+    [4, 4],
+]
+TEST_2D_POOL = [
+    {
+        "num_d": 4,
+        "num_layers_d": 3,
+        "spatial_dims": 2,
+        "num_channels": 8,
+        "in_channels": 3,
+        "out_channels": 1,
+        "kernel_size": 3,
+        "pooling_method": "avg",
+        "activation": "LEAKYRELU",
+        "norm": "instance",
+        "bias": False,
+        "dropout": 0.1,
+        "minimum_size_im": 256,
+    },
+    torch.rand([1, 3, 256, 512]),
+    [(1, 1, 32, 64), (1, 1, 16, 32), (1, 1, 8, 16), (1, 1, 4, 8)],
+    [4, 4, 4, 4],
+]
+TEST_LAYER_LIST = [
+    {
+        "num_d": 3,
+        "num_layers_d": [3,4,5],
+        "spatial_dims": 2,
+        "num_channels": 8,
+        "in_channels": 3,
+        "out_channels": 1,
+        "kernel_size": 3,
+        "activation": "LEAKYRELU",
+        "norm": "instance",
+        "bias": False,
+        "dropout": 0.1,
+        "minimum_size_im": 256,
+    },
+    torch.rand([1, 3, 256, 512]),
+    [(1, 1, 32, 64), (1, 1, 16, 32), (1, 1, 8, 16)],
+    [4, 5, 6],
+]
 TEST_TOO_SMALL_SIZE = [
     {
         "num_d": 2,
@@ -74,9 +133,24 @@ TEST_TOO_SMALL_SIZE = [
         "minimum_size_im": 256,
     }
 ]
+TEST_MISMATCHED_NUM_LAYERS = [
+    {
+        "num_d": 5,
+        "num_layers_d": [3,4,5],
+        "spatial_dims": 2,
+        "num_channels": 8,
+        "in_channels": 3,
+        "out_channels": 1,
+        "kernel_size": 3,
+        "activation": "LEAKYRELU",
+        "norm": "instance",
+        "bias": False,
+        "dropout": 0.1,
+        "minimum_size_im": 256,
+    }
+]
 
-CASES = [TEST_2D, TEST_3D]
-
+CASES = [TEST_2D, TEST_3D, TEST_3D_POOL, TEST_2D_POOL, TEST_LAYER_LIST]
 
 class TestPatchGAN(unittest.TestCase):
     @parameterized.expand(CASES)
@@ -92,6 +166,10 @@ class TestPatchGAN(unittest.TestCase):
     def test_too_small_shape(self):
         with self.assertRaises(AssertionError):
             MultiScalePatchDiscriminator(**TEST_TOO_SMALL_SIZE[0])
+
+    def test_mismatched_num_layers(self):
+        with self.assertRaises(AssertionError):
+            MultiScalePatchDiscriminator(**TEST_MISMATCHED_NUM_LAYERS[0])
 
     def test_script(self):
         net = MultiScalePatchDiscriminator(

--- a/tutorials/generative/2d_spade_gan/2d_spade_vae.py
+++ b/tutorials/generative/2d_spade_gan/2d_spade_vae.py
@@ -44,126 +44,11 @@ from generative.losses import PatchAdversarialLoss, PerceptualLoss
 from generative.networks.nets import MultiScalePatchDiscriminator
 import numpy as np
 import monai
-from generative.networks.nets.spade_network import SPADE_Net
+from generative.networks.nets.spade_network import SPADENet
 
-directory = os.environ.get("MONAI_DATA_DIRECTORY")
-root_dir = tempfile.mkdtemp() if directory is None else directory
-root_dir = Path(root_dir)
-print("Temporary directory used: %s " % root_dir)
-
-# INPUT PARAMETERS
-input_shape = [128, 128]
-batch_size = 6
-num_workers = 4
-num_epochs = 100
-lambda_perc = 1.0
-lambda_feat = 0.1
-lambda_kld = 0.00001
-loss_adv = 1.0
-
-# ### Data
-
-# The data for this notebook comes from the public dataset OASIS (Open Access Series of Imaging Studies) [1]. The images have been registered to MNI space using ANTsPy, and then subsampled to 2mm isotropic resolution. Geodesic Information Flows (GIF) [2] has been used to segment 5 regions: cerebrospinal fluid (CSF), grey matter (GM), white matter (WM), deep grey matter (DGM) and brainstem. In addition, BaMos [3] has been used to provide white matter hyperintensities segmentations (WMH). The available dataset contains:
-# - T1-weighted images
-# - FLAIR weighted images
-# - Segmentations with the following labels: 0 (background), 1 (CSF), 2 (GM), 3 (WM), 4 (DGM), 5 (brainstem) and 6 (WMH).
-#
-# _**Acknowledgments**: "Data were provided by OASIS-3: Longitudinal Multimodal Neuroimaging: Principal Investigators: T. Benzinger, D. Marcus, J. Morris; NIH P30 AG066444, P50 AG00561, P30 NS09857781, P01 AG026276, P01 AG003991, R01 AG043434, UL1 TR000448, R01 EB009352. AV-45 doses were provided by Avid Radiopharmaceuticals, a wholly owned subsidiary of Eli Lilly.”_
-#
-#
-# Citations:
-#
-# [1] Marcus, DS, Wang, TH, Parker, J, Csernansky, JG, Morris, JC, Buckner. Open Access Series of Imaging Studies (OASIS): Cross-Sectional MRI Data in Young, Middle Aged, Nondemented, and Demented Older Adults, RL. Journal of Cognitive Neuroscience, 19, 1498-1507. doi: 10.1162/jocn.2007.19.9.1498
-#
-# [2] Cardoso MJ, Modat M, Wolz R, Melbourne A, Cash D, Rueckert D, Ourselin S. Geodesic Information Flows: Spatially-Variant Graphs and Their Application to Segmentation and Fusion. IEEE Trans Med Imaging. 2015 Sep;34(9):1976-88. doi: 10.1109/TMI.2015.2418298. Epub 2015 Apr 14. PMID: 25879909.
-#
-# [3] Fiford CM, Sudre CH, Pemberton H, Walsh P, Manning E, Malone IB, Nicholas J, Bouvy WH, Carmichael OT, Biessels GJ, Cardoso MJ, Barnes J; Alzheimer’s Disease Neuroimaging Initiative. Automated White Matter Hyperintensity Segmentation Using Bayesian Model Selection: Assessment and Correlations with Cognitive Change. Neuroinformatics. 2020 Jun;18(3):429-449. doi: 10.1007/s12021-019-09439-6. PMID: 32062817; PMCID: PMC7338814.
-#
-
-gdown.download(
-    "https://drive.google.com/uc?export=download&id=1SX_MCzQe-vyq09QYxECk32wZ2vxp9rx5", str(root_dir / "data.zip")
-)
-
-zip_obj = zipfile.ZipFile(os.path.join(root_dir, "data.zip"), "r")
-zip_obj.extractall(root_dir)
-images_T1 = root_dir / "OASIS_SMALL-SUBSET/T1"
-images_FLAIR = root_dir / "OASIS_SMALL-SUBSET/FLAIR"
-labels = root_dir / "OASIS_SMALL-SUBSET/Segmentations"
-
-# We create the data dictionaries that we need
-all_images = [os.path.join(images_T1, i) for i in os.listdir(images_T1)] + [
-    os.path.join(images_FLAIR, i) for i in os.listdir(images_FLAIR)
-]
-np.random.shuffle(all_images)
-corresponding_labels = [
-    os.path.join(labels, i.split("/")[-1].replace(i.split("/")[-1].split("_")[0], "Parcellation")) for i in all_images
-]
-input_dict = [{"image": i, "label": corresponding_labels[ind]} for ind, i in enumerate(all_images)]
-input_dict_train = input_dict[: int(len(input_dict) * 0.9)]
-input_dict_val = input_dict[int(len(input_dict) * 0.9) :]
-
-# ### Dataloaders
-
-# +
-preliminar_shape = input_shape + [50]  # We take random slices fron the center of the brain
-crop_shape = input_shape + [1]
-base_transforms = [
-    monai.transforms.LoadImaged(keys=["label", "image"]),
-    monai.transforms.EnsureChannelFirstd(keys=["image", "label"]),
-    monai.transforms.CenterSpatialCropd(keys=["label", "image"], roi_size=preliminar_shape),
-    monai.transforms.RandSpatialCropd(keys=["label", "image"], roi_size=crop_shape, max_roi_size=crop_shape),
-    monai.transforms.SqueezeDimd(keys=["label", "image"], dim=-1),
-    monai.transforms.Resized(keys=["image", "label"], spatial_size=input_shape),
-]
-last_transforms = [
-    monai.transforms.CopyItemsd(keys=["label"], names=["label_channel"]),
-    monai.transforms.Lambdad(keys=["label_channel"], func=lambda l: l != 0),
-    monai.transforms.MaskIntensityd(keys=["image"], mask_key="label_channel"),
-    monai.transforms.NormalizeIntensityd(keys=["image"]),
-    monai.transforms.ToTensord(keys=["image", "label"]),
-]
-
-aug_transforms = [
-    monai.transforms.RandBiasFieldd(coeff_range=(0, 0.005), prob=0.33, keys=["image"]),
-    monai.transforms.RandAdjustContrastd(gamma=(0.9, 1.15), prob=0.33, keys=["image"]),
-    monai.transforms.RandGaussianNoised(prob=0.33, mean=0.0, std=np.random.uniform(0.005, 0.015), keys=["image"]),
-    monai.transforms.RandAffined(
-        rotate_range=[-0.05, 0.05],
-        shear_range=[0.001, 0.05],
-        scale_range=[0, 0.05],
-        padding_mode="zeros",
-        mode="nearest",
-        prob=0.33,
-        keys=["label", "image"],
-    ),
-]
-
-train_transforms = monai.transforms.Compose(base_transforms + aug_transforms + last_transforms)
-val_transforms = monai.transforms.Compose(base_transforms + last_transforms)
-
-train_dataset = monai.data.dataset.Dataset(input_dict_train, train_transforms)
-val_dataset = monai.data.dataset.Dataset(input_dict_val, val_transforms)
-train_loader = DataLoader(train_dataset, shuffle=True, batch_size=batch_size, num_workers=num_workers)
-val_loader = DataLoader(val_dataset, shuffle=False, drop_last=False, batch_size=batch_size, num_workers=num_workers)
-
-
-# -
-
-# Sanity check
-batch = next(iter(train_loader))
-print(batch["image"].shape)
-plt.subplot(1, 2, 1)
-plt.imshow(batch["image"][0, 0, ...], cmap="gist_gray")
-plt.axis("off")
-plt.subplot(1, 2, 2)
-plt.imshow(batch["label"][0, 0, ...], cmap="jet")
-plt.axis("off")
-plt.show()
-
-# ### Network creation and losses
-
-device = "cuda" if torch.cuda.is_available() else "cpu"
-
+#Functions to be used in the main script
+def _masked_area(x):
+    return x != 0
 
 def one_hot(input_label, label_nc):
     # One hot encoding function for the labels
@@ -203,103 +88,176 @@ def feature_loss(input_features_disc_fake, input_features_disc_real, lambda_feat
             GAN_Feat_loss += unweighted_loss * lambda_feat / num_D
     return GAN_Feat_loss
 
+def main():
+    directory = os.environ.get("MONAI_DATA_DIRECTORY")
+    root_dir = tempfile.mkdtemp() if directory is None else directory
+    root_dir = Path(root_dir)
+    print("Temporary directory used: %s " % root_dir)
 
-net = SPADE_Net(
-    spatial_dims=2,
-    in_channels=1,
-    out_channels=1,
-    label_nc=6,
-    input_shape=input_shape,
-    num_channels=[16, 32, 64, 128],
-    z_dim=16,
-    is_vae=True,
-)
+    # INPUT PARAMETERS
+    input_shape = [128, 128]
+    batch_size = 6
+    num_workers = 4
+    num_epochs = 100
+    lambda_perc = 1.0
+    lambda_feat = 0.1
+    lambda_kld = 0.00001
+    loss_adv = 1.0
 
-# +
-discriminator = MultiScalePatchDiscriminator(
-    num_d=2,
-    num_layers_d=3,
-    spatial_dims=2,
-    num_channels=8,
-    in_channels=7,
-    out_channels=7,
-    minimum_size_im=128,
-    norm="INSTANCE",
-    kernel_size=3,
-)
+    # ### Data
 
-adversarial_loss = PatchAdversarialLoss(reduction="sum", criterion="hinge")
-# -
-
-perceptual_loss = PerceptualLoss(spatial_dims=2, network_type="vgg", is_fake_3d=False, pretrained=True)
-perceptual_loss = perceptual_loss.to(device)
-
-optimizer_G = torch.optim.Adam(net.parameters(), lr=0.0002)
-optimizer_D = torch.optim.Adam(discriminator.parameters(), lr=0.0004)
-
-# ### Training loop
-#
-
-net = net.to(device)
-discriminator = discriminator.to(device)
-torch.autograd.set_detect_anomaly(True)
-losses = {"kld": [], "perceptual": [], "feature": [], "generator": [], "discriminator": []}
-losses_val = {"kld": [], "perceptual": [], "feature": [], "generator": [], "discriminator": []}
-for epoch in range(num_epochs):
-    print("Epoch %d/%d" % (epoch, num_epochs))
-    train_bar = tqdm(enumerate(train_loader), total=len(train_loader), ncols=120)
-    losses_epoch = {"kld": 0, "perceptual": 0, "feature": 0, "generator": 0, "discriminator": 0}
-    for step, d in train_bar:
-        image = d["image"].to(device)
-        with torch.no_grad():
-            label = one_hot(d["label"], 6).to(device)
-        optimizer_G.zero_grad()
-
-        # Losses gen
-        out, kld_loss = net(label, image)
-        disc_fakes, features_fakes = discriminator(torch.cat([out, label], 1))
-        loss_g = adversarial_loss(disc_fakes, target_is_real=True, for_discriminator=False)
-        disc_reals, features_reals = discriminator(torch.cat([image, label], 1))
-        loss_feat = feature_loss(features_fakes, features_reals, lambda_feat, device)
-        loss_perc = perceptual_loss(out, target=image)
-        total_loss = loss_g + loss_perc * lambda_perc + kld_loss * lambda_kld + loss_feat * lambda_feat
-        total_loss.backward(retain_graph=True)
-        optimizer_G.step()
-
-        # Store
-        losses_epoch["kld"] += kld_loss.item()
-        losses_epoch["perceptual"] += loss_perc.item()
-        losses_epoch["generator"] += loss_g.item()
-        # Train disc
-        out, _ = net(label, image)
-        disc_fakes, _ = discriminator(torch.cat([out, label], 1))
-        loss_d_r = adversarial_loss(disc_reals, target_is_real=True, for_discriminator=True)
-        loss_g_f = adversarial_loss(disc_fakes, target_is_real=False, for_discriminator=True)
-        optimizer_D.zero_grad()
-        loss_d = loss_d_r + loss_g_f
-        loss_d.backward()
-        optimizer_D.step()
-
-        # Store
-        losses_epoch["feature"] = loss_feat.item()
-        losses_epoch["discriminator"] = loss_d_r.item() + loss_g_f.item()
-
-        train_bar.set_postfix(
-            {
-                "kld": kld_loss.item(),
-                "perceptual": loss_perc.item(),
-                "generator": loss_g.item(),
-                "feature": loss_feat.item(),
-                "discriminator": loss_d_r.item() + loss_g_f.item(),
-            }
+    # The data for this notebook comes from the public dataset OASIS (Open Access Series of Imaging Studies) [1]. The images have been registered to MNI space using ANTsPy, and then subsampled to 2mm isotropic resolution. Geodesic Information Flows (GIF) [2] has been used to segment 5 regions: cerebrospinal fluid (CSF), grey matter (GM), white matter (WM), deep grey matter (DGM) and brainstem. In addition, BaMos [3] has been used to provide white matter hyperintensities segmentations (WMH). The available dataset contains:
+    # - T1-weighted images
+    # - FLAIR weighted images
+    # - Segmentations with the following labels: 0 (background), 1 (CSF), 2 (GM), 3 (WM), 4 (DGM), 5 (brainstem) and 6 (WMH).
+    #
+    # _**Acknowledgments**: "Data were provided by OASIS-3: Longitudinal Multimodal Neuroimaging: Principal Investigators: T. Benzinger, D. Marcus, J. Morris; NIH P30 AG066444, P50 AG00561, P30 NS09857781, P01 AG026276, P01 AG003991, R01 AG043434, UL1 TR000448, R01 EB009352. AV-45 doses were provided by Avid Radiopharmaceuticals, a wholly owned subsidiary of Eli Lilly.”_
+    #
+    #
+    # Citations:
+    #
+    # [1] Marcus, DS, Wang, TH, Parker, J, Csernansky, JG, Morris, JC, Buckner. Open Access Series of Imaging Studies (OASIS): Cross-Sectional MRI Data in Young, Middle Aged, Nondemented, and Demented Older Adults, RL. Journal of Cognitive Neuroscience, 19, 1498-1507. doi: 10.1162/jocn.2007.19.9.1498
+    #
+    # [2] Cardoso MJ, Modat M, Wolz R, Melbourne A, Cash D, Rueckert D, Ourselin S. Geodesic Information Flows: Spatially-Variant Graphs and Their Application to Segmentation and Fusion. IEEE Trans Med Imaging. 2015 Sep;34(9):1976-88. doi: 10.1109/TMI.2015.2418298. Epub 2015 Apr 14. PMID: 25879909.
+    #
+    # [3] Fiford CM, Sudre CH, Pemberton H, Walsh P, Manning E, Malone IB, Nicholas J, Bouvy WH, Carmichael OT, Biessels GJ, Cardoso MJ, Barnes J; Alzheimer’s Disease Neuroimaging Initiative. Automated White Matter Hyperintensity Segmentation Using Bayesian Model Selection: Assessment and Correlations with Cognitive Change. Neuroinformatics. 2020 Jun;18(3):429-449. doi: 10.1007/s12021-019-09439-6. PMID: 32062817; PMCID: PMC7338814.
+    #
+    if not (root_dir / "data.zip").exists():
+        gdown.download(
+            "https://drive.google.com/uc?export=download&id=1SX_MCzQe-vyq09QYxECk32wZ2vxp9rx5", str(root_dir / "data.zip")
         )
+        zip_obj = zipfile.ZipFile(os.path.join(root_dir, "data.zip"), "r")
+        zip_obj.extractall(root_dir)
+    images_T1 = root_dir / "OASIS_SMALL-SUBSET/T1"
+    images_FLAIR = root_dir / "OASIS_SMALL-SUBSET/FLAIR"
+    labels = root_dir / "OASIS_SMALL-SUBSET/Segmentations"
 
-    val_bar = tqdm(enumerate(val_loader), total=len(val_loader), ncols=120)
-    losses_epoch_val = {"kld": 0, "perceptual": 0, "feature": 0, "generator": 0, "discriminator": 0}
-    for step, d in val_bar:
-        image = d["image"].to(device)
-        with torch.no_grad():
-            label = one_hot(d["label"], 6).to(device)
+    # We create the data dictionaries that we need
+    all_images = [os.path.join(images_T1, i) for i in os.listdir(images_T1)] + [
+        os.path.join(images_FLAIR, i) for i in os.listdir(images_FLAIR)
+    ]
+    np.random.shuffle(all_images)
+    corresponding_labels = [
+        os.path.join(labels, os.path.basename(i).replace(os.path.basename(i).split("_")[0], "Parcellation")) for i in all_images
+    ]
+    input_dict = [{"image": i, "label": corresponding_labels[ind]} for ind, i in enumerate(all_images)]
+    input_dict_train = input_dict[: int(len(input_dict) * 0.9)]
+    input_dict_val = input_dict[int(len(input_dict) * 0.9) :]
+
+    # ### Dataloaders
+
+    # +
+    preliminar_shape = input_shape + [50]  # We take random slices fron the center of the brain
+    crop_shape = input_shape + [1]
+
+    base_transforms = [
+        monai.transforms.LoadImaged(keys=["label", "image"], image_only=False),
+        monai.transforms.EnsureChannelFirstd(keys=["image", "label"]),
+        monai.transforms.CenterSpatialCropd(keys=["label", "image"], roi_size=preliminar_shape),
+        monai.transforms.RandSpatialCropd(keys=["label", "image"], roi_size=crop_shape, max_roi_size=crop_shape, random_size=True),
+        monai.transforms.SqueezeDimd(keys=["label", "image"], dim=-1),
+        monai.transforms.Resized(keys=["image", "label"], spatial_size=input_shape),
+    ]
+    last_transforms = [
+        monai.transforms.CopyItemsd(keys=["label"], names=["label_channel"]),
+        monai.transforms.Lambdad(keys=["label_channel"], func=_masked_area),
+        monai.transforms.MaskIntensityd(keys=["image"], mask_key="label_channel"),
+        monai.transforms.NormalizeIntensityd(keys=["image"]),
+        monai.transforms.ToTensord(keys=["image", "label"]),
+    ]
+
+    aug_transforms = [
+        monai.transforms.RandBiasFieldd(coeff_range=(0, 0.005), prob=0.33, keys=["image"]),
+        monai.transforms.RandAdjustContrastd(gamma=(0.9, 1.15), prob=0.33, keys=["image"]),
+        monai.transforms.RandGaussianNoised(prob=0.33, mean=0.0, std=np.random.uniform(0.005, 0.015), keys=["image"]),
+        monai.transforms.RandAffined(
+            rotate_range=[-0.05, 0.05],
+            shear_range=[0.001, 0.05],
+            scale_range=[0, 0.05],
+            padding_mode="zeros",
+            mode="nearest",
+            prob=0.33,
+            keys=["label", "image"],
+        ),
+    ]
+
+    train_transforms = monai.transforms.Compose(base_transforms + aug_transforms + last_transforms)
+    val_transforms = monai.transforms.Compose(base_transforms + last_transforms)
+
+    train_dataset = monai.data.dataset.Dataset(input_dict_train, train_transforms)
+    val_dataset = monai.data.dataset.Dataset(input_dict_val, val_transforms)
+    train_loader = DataLoader(train_dataset, shuffle=True, batch_size=batch_size, num_workers=num_workers)
+    val_loader = DataLoader(val_dataset, shuffle=False, drop_last=False, batch_size=batch_size, num_workers=num_workers)
+
+
+    # -
+
+    # Sanity check
+    batch = next(iter(train_loader))
+    print(batch["image"].shape)
+    plt.subplot(1, 2, 1)
+    plt.imshow(batch["image"][0, 0, ...], cmap="gist_gray")
+    plt.axis("off")
+    plt.subplot(1, 2, 2)
+    plt.imshow(batch["label"][0, 0, ...], cmap="jet")
+    plt.axis("off")
+    plt.show()
+
+    # ### Network creation and losses
+
+    device = "cuda" if torch.cuda.is_available() else "cpu"
+
+    net = SPADENet(
+        spatial_dims=2,
+        in_channels=1,
+        out_channels=1,
+        label_nc=6,
+        input_shape=input_shape,
+        num_channels=[16, 32, 64, 128],
+        z_dim=16,
+        is_vae=True,
+    )
+
+    # +
+    discriminator = MultiScalePatchDiscriminator(
+        num_d=2,
+        num_layers_d=3,
+        spatial_dims=2,
+        num_channels=8,
+        in_channels=7,
+        out_channels=7,
+        minimum_size_im=128,
+        norm="INSTANCE",
+        kernel_size=3,
+    )
+
+    adversarial_loss = PatchAdversarialLoss(reduction="sum", criterion="hinge")
+    # -
+
+    perceptual_loss = PerceptualLoss(spatial_dims=2, network_type="vgg", is_fake_3d=False, pretrained=True)
+    perceptual_loss = perceptual_loss.to(device)
+
+    optimizer_G = torch.optim.Adam(net.parameters(), lr=0.0002)
+    optimizer_D = torch.optim.Adam(discriminator.parameters(), lr=0.0004)
+
+    # ### Training loop
+    #
+
+    net = net.to(device)
+    discriminator = discriminator.to(device)
+    torch.autograd.set_detect_anomaly(True)
+    losses = {"kld": [], "perceptual": [], "feature": [], "generator": [], "discriminator": []}
+    losses_val = {"kld": [], "perceptual": [], "feature": [], "generator": [], "discriminator": []}
+    for epoch in range(num_epochs):
+        print("Epoch %d/%d" % (epoch, num_epochs))
+        train_bar = tqdm(enumerate(train_loader), total=len(train_loader), ncols=120)
+        losses_epoch = {"kld": 0, "perceptual": 0, "feature": 0, "generator": 0, "discriminator": 0}
+        for step, d in train_bar:
+            image = d["image"].to(device)
+            with torch.no_grad():
+                label = one_hot(d["label"], 6).to(device)
+            optimizer_G.zero_grad()
+
             # Losses gen
             out, kld_loss = net(label, image)
             disc_fakes, features_fakes = discriminator(torch.cat([out, label], 1))
@@ -307,23 +265,29 @@ for epoch in range(num_epochs):
             disc_reals, features_reals = discriminator(torch.cat([image, label], 1))
             loss_feat = feature_loss(features_fakes, features_reals, lambda_feat, device)
             loss_perc = perceptual_loss(out, target=image)
-            total_loss = loss_adv * loss_g + loss_perc * lambda_perc + kld_loss * lambda_kld + loss_feat * lambda_feat
+            total_loss = loss_g + loss_perc * lambda_perc + kld_loss * lambda_kld + loss_feat * lambda_feat
+            total_loss.backward(retain_graph=True)
+            optimizer_G.step()
+
             # Store
-            losses_epoch_val["kld"] += kld_loss.item()
-            losses_epoch_val["perceptual"] += loss_perc.item()
-            losses_epoch_val["generator"] += loss_g.item()
+            losses_epoch["kld"] += kld_loss.item()
+            losses_epoch["perceptual"] += loss_perc.item()
+            losses_epoch["generator"] += loss_g.item()
             # Train disc
             out, _ = net(label, image)
             disc_fakes, _ = discriminator(torch.cat([out, label], 1))
             loss_d_r = adversarial_loss(disc_reals, target_is_real=True, for_discriminator=True)
             loss_g_f = adversarial_loss(disc_fakes, target_is_real=False, for_discriminator=True)
-            loss_d = loss_adv * (loss_d_r + loss_g_f)
+            optimizer_D.zero_grad()
+            loss_d = loss_d_r + loss_g_f
+            loss_d.backward()
+            optimizer_D.step()
 
             # Store
-            losses_epoch_val["feature"] = loss_feat.item()
-            losses_epoch_val["discriminator"] = loss_d_r.item() + loss_g_f.item()
+            losses_epoch["feature"] = loss_feat.item()
+            losses_epoch["discriminator"] = loss_d_r.item() + loss_g_f.item()
 
-            val_bar.set_postfix(
+            train_bar.set_postfix(
                 {
                     "kld": kld_loss.item(),
                     "perceptual": loss_perc.item(),
@@ -332,29 +296,71 @@ for epoch in range(num_epochs):
                     "discriminator": loss_d_r.item() + loss_g_f.item(),
                 }
             )
-            if step == 0 and epoch % 10 == 0:
-                picture_results(label, image, out)
-    for key, val in losses_epoch.items():
-        losses[key].append(val / len(train_loader))
-    for key, val in losses_epoch_val.items():
-        losses_val[key].append(val / len(val_loader))
+
+        val_bar = tqdm(enumerate(val_loader), total=len(val_loader), ncols=120)
+        losses_epoch_val = {"kld": 0, "perceptual": 0, "feature": 0, "generator": 0, "discriminator": 0}
+        for step, d in val_bar:
+            image = d["image"].to(device)
+            with torch.no_grad():
+                label = one_hot(d["label"], 6).to(device)
+                # Losses gen
+                out, kld_loss = net(label, image)
+                disc_fakes, features_fakes = discriminator(torch.cat([out, label], 1))
+                loss_g = adversarial_loss(disc_fakes, target_is_real=True, for_discriminator=False)
+                disc_reals, features_reals = discriminator(torch.cat([image, label], 1))
+                loss_feat = feature_loss(features_fakes, features_reals, lambda_feat, device)
+                loss_perc = perceptual_loss(out, target=image)
+                total_loss = loss_adv * loss_g + loss_perc * lambda_perc + kld_loss * lambda_kld + loss_feat * lambda_feat
+                # Store
+                losses_epoch_val["kld"] += kld_loss.item()
+                losses_epoch_val["perceptual"] += loss_perc.item()
+                losses_epoch_val["generator"] += loss_g.item()
+                # Train disc
+                out, _ = net(label, image)
+                disc_fakes, _ = discriminator(torch.cat([out, label], 1))
+                loss_d_r = adversarial_loss(disc_reals, target_is_real=True, for_discriminator=True)
+                loss_g_f = adversarial_loss(disc_fakes, target_is_real=False, for_discriminator=True)
+                loss_d = loss_adv * (loss_d_r + loss_g_f)
+
+                # Store
+                losses_epoch_val["feature"] = loss_feat.item()
+                losses_epoch_val["discriminator"] = loss_d_r.item() + loss_g_f.item()
+
+                val_bar.set_postfix(
+                    {
+                        "kld": kld_loss.item(),
+                        "perceptual": loss_perc.item(),
+                        "generator": loss_g.item(),
+                        "feature": loss_feat.item(),
+                        "discriminator": loss_d_r.item() + loss_g_f.item(),
+                    }
+                )
+                if step == 0 and epoch % 10 == 0:
+                    picture_results(label, image, out)
+        for key, val in losses_epoch.items():
+            losses[key].append(val / len(train_loader))
+        for key, val in losses_epoch_val.items():
+            losses_val[key].append(val / len(val_loader))
 
 
-# Plot losses
-colors = ["orangered", "royalblue", "hotpink", "lime", "goldenrod"]
-plt.figure(figsize=(5, 10))
-ind = 0
-for key, val in losses.items():
-    plt.subplot(len(losses.keys()), 1, ind + 1)
-    plt.plot(val, color=colors[ind], linestyle="-")
-    plt.plot(losses_val[key], color=colors[ind], linestyle="--")
-    plt.title(key)
-    plt.xlabel("Epochs")
-    ind += 1
-plt.tight_layout()
-plt.show()
+    # Plot losses
+    colors = ["orangered", "royalblue", "hotpink", "lime", "goldenrod"]
+    plt.figure(figsize=(5, 10))
+    ind = 0
+    for key, val in losses.items():
+        plt.subplot(len(losses.keys()), 1, ind + 1)
+        plt.plot(val, color=colors[ind], linestyle="-")
+        plt.plot(losses_val[key], color=colors[ind], linestyle="--")
+        plt.title(key)
+        plt.xlabel("Epochs")
+        ind += 1
+    plt.tight_layout()
+    plt.show()
 
 # + [markdown] pycharm={"name": "#%%"}
 # **Conclusion**: from early on, the network shows the capability of discern between the different semantic layers. To achieve good image quality, more images and training time are needed (to avoid overfitting, seen in some loss plots of previous example), as well as thorough optimisation, such as establishing an adversarial schedule that makes sure that the discriminator and generator and the discriminator are trained only when their performance does not exceed a certain limit.
 #
 # -
+
+if __name__ == "__main__":
+    main()

--- a/tutorials/generative/2d_spade_gan/2d_spade_vae.py
+++ b/tutorials/generative/2d_spade_gan/2d_spade_vae.py
@@ -44,11 +44,126 @@ from generative.losses import PatchAdversarialLoss, PerceptualLoss
 from generative.networks.nets import MultiScalePatchDiscriminator
 import numpy as np
 import monai
-from generative.networks.nets.spade_network import SPADENet
+from generative.networks.nets.spade_network import SPADE_Net
 
-#Functions to be used in the main script
-def _masked_area(x):
-    return x != 0
+directory = os.environ.get("MONAI_DATA_DIRECTORY")
+root_dir = tempfile.mkdtemp() if directory is None else directory
+root_dir = Path(root_dir)
+print("Temporary directory used: %s " % root_dir)
+
+# INPUT PARAMETERS
+input_shape = [128, 128]
+batch_size = 6
+num_workers = 4
+num_epochs = 100
+lambda_perc = 1.0
+lambda_feat = 0.1
+lambda_kld = 0.00001
+loss_adv = 1.0
+
+# ### Data
+
+# The data for this notebook comes from the public dataset OASIS (Open Access Series of Imaging Studies) [1]. The images have been registered to MNI space using ANTsPy, and then subsampled to 2mm isotropic resolution. Geodesic Information Flows (GIF) [2] has been used to segment 5 regions: cerebrospinal fluid (CSF), grey matter (GM), white matter (WM), deep grey matter (DGM) and brainstem. In addition, BaMos [3] has been used to provide white matter hyperintensities segmentations (WMH). The available dataset contains:
+# - T1-weighted images
+# - FLAIR weighted images
+# - Segmentations with the following labels: 0 (background), 1 (CSF), 2 (GM), 3 (WM), 4 (DGM), 5 (brainstem) and 6 (WMH).
+#
+# _**Acknowledgments**: "Data were provided by OASIS-3: Longitudinal Multimodal Neuroimaging: Principal Investigators: T. Benzinger, D. Marcus, J. Morris; NIH P30 AG066444, P50 AG00561, P30 NS09857781, P01 AG026276, P01 AG003991, R01 AG043434, UL1 TR000448, R01 EB009352. AV-45 doses were provided by Avid Radiopharmaceuticals, a wholly owned subsidiary of Eli Lilly.”_
+#
+#
+# Citations:
+#
+# [1] Marcus, DS, Wang, TH, Parker, J, Csernansky, JG, Morris, JC, Buckner. Open Access Series of Imaging Studies (OASIS): Cross-Sectional MRI Data in Young, Middle Aged, Nondemented, and Demented Older Adults, RL. Journal of Cognitive Neuroscience, 19, 1498-1507. doi: 10.1162/jocn.2007.19.9.1498
+#
+# [2] Cardoso MJ, Modat M, Wolz R, Melbourne A, Cash D, Rueckert D, Ourselin S. Geodesic Information Flows: Spatially-Variant Graphs and Their Application to Segmentation and Fusion. IEEE Trans Med Imaging. 2015 Sep;34(9):1976-88. doi: 10.1109/TMI.2015.2418298. Epub 2015 Apr 14. PMID: 25879909.
+#
+# [3] Fiford CM, Sudre CH, Pemberton H, Walsh P, Manning E, Malone IB, Nicholas J, Bouvy WH, Carmichael OT, Biessels GJ, Cardoso MJ, Barnes J; Alzheimer’s Disease Neuroimaging Initiative. Automated White Matter Hyperintensity Segmentation Using Bayesian Model Selection: Assessment and Correlations with Cognitive Change. Neuroinformatics. 2020 Jun;18(3):429-449. doi: 10.1007/s12021-019-09439-6. PMID: 32062817; PMCID: PMC7338814.
+#
+
+gdown.download(
+    "https://drive.google.com/uc?export=download&id=1SX_MCzQe-vyq09QYxECk32wZ2vxp9rx5", str(root_dir / "data.zip")
+)
+
+zip_obj = zipfile.ZipFile(os.path.join(root_dir, "data.zip"), "r")
+zip_obj.extractall(root_dir)
+images_T1 = root_dir / "OASIS_SMALL-SUBSET/T1"
+images_FLAIR = root_dir / "OASIS_SMALL-SUBSET/FLAIR"
+labels = root_dir / "OASIS_SMALL-SUBSET/Segmentations"
+
+# We create the data dictionaries that we need
+all_images = [os.path.join(images_T1, i) for i in os.listdir(images_T1)] + [
+    os.path.join(images_FLAIR, i) for i in os.listdir(images_FLAIR)
+]
+np.random.shuffle(all_images)
+corresponding_labels = [
+    os.path.join(labels, i.split("/")[-1].replace(i.split("/")[-1].split("_")[0], "Parcellation")) for i in all_images
+]
+input_dict = [{"image": i, "label": corresponding_labels[ind]} for ind, i in enumerate(all_images)]
+input_dict_train = input_dict[: int(len(input_dict) * 0.9)]
+input_dict_val = input_dict[int(len(input_dict) * 0.9) :]
+
+# ### Dataloaders
+
+# +
+preliminar_shape = input_shape + [50]  # We take random slices fron the center of the brain
+crop_shape = input_shape + [1]
+base_transforms = [
+    monai.transforms.LoadImaged(keys=["label", "image"]),
+    monai.transforms.EnsureChannelFirstd(keys=["image", "label"]),
+    monai.transforms.CenterSpatialCropd(keys=["label", "image"], roi_size=preliminar_shape),
+    monai.transforms.RandSpatialCropd(keys=["label", "image"], roi_size=crop_shape, max_roi_size=crop_shape),
+    monai.transforms.SqueezeDimd(keys=["label", "image"], dim=-1),
+    monai.transforms.Resized(keys=["image", "label"], spatial_size=input_shape),
+]
+last_transforms = [
+    monai.transforms.CopyItemsd(keys=["label"], names=["label_channel"]),
+    monai.transforms.Lambdad(keys=["label_channel"], func=lambda l: l != 0),
+    monai.transforms.MaskIntensityd(keys=["image"], mask_key="label_channel"),
+    monai.transforms.NormalizeIntensityd(keys=["image"]),
+    monai.transforms.ToTensord(keys=["image", "label"]),
+]
+
+aug_transforms = [
+    monai.transforms.RandBiasFieldd(coeff_range=(0, 0.005), prob=0.33, keys=["image"]),
+    monai.transforms.RandAdjustContrastd(gamma=(0.9, 1.15), prob=0.33, keys=["image"]),
+    monai.transforms.RandGaussianNoised(prob=0.33, mean=0.0, std=np.random.uniform(0.005, 0.015), keys=["image"]),
+    monai.transforms.RandAffined(
+        rotate_range=[-0.05, 0.05],
+        shear_range=[0.001, 0.05],
+        scale_range=[0, 0.05],
+        padding_mode="zeros",
+        mode="nearest",
+        prob=0.33,
+        keys=["label", "image"],
+    ),
+]
+
+train_transforms = monai.transforms.Compose(base_transforms + aug_transforms + last_transforms)
+val_transforms = monai.transforms.Compose(base_transforms + last_transforms)
+
+train_dataset = monai.data.dataset.Dataset(input_dict_train, train_transforms)
+val_dataset = monai.data.dataset.Dataset(input_dict_val, val_transforms)
+train_loader = DataLoader(train_dataset, shuffle=True, batch_size=batch_size, num_workers=num_workers)
+val_loader = DataLoader(val_dataset, shuffle=False, drop_last=False, batch_size=batch_size, num_workers=num_workers)
+
+
+# -
+
+# Sanity check
+batch = next(iter(train_loader))
+print(batch["image"].shape)
+plt.subplot(1, 2, 1)
+plt.imshow(batch["image"][0, 0, ...], cmap="gist_gray")
+plt.axis("off")
+plt.subplot(1, 2, 2)
+plt.imshow(batch["label"][0, 0, ...], cmap="jet")
+plt.axis("off")
+plt.show()
+
+# ### Network creation and losses
+
+device = "cuda" if torch.cuda.is_available() else "cpu"
+
 
 def one_hot(input_label, label_nc):
     # One hot encoding function for the labels
@@ -88,176 +203,103 @@ def feature_loss(input_features_disc_fake, input_features_disc_real, lambda_feat
             GAN_Feat_loss += unweighted_loss * lambda_feat / num_D
     return GAN_Feat_loss
 
-def main():
-    directory = os.environ.get("MONAI_DATA_DIRECTORY")
-    root_dir = tempfile.mkdtemp() if directory is None else directory
-    root_dir = Path(root_dir)
-    print("Temporary directory used: %s " % root_dir)
 
-    # INPUT PARAMETERS
-    input_shape = [128, 128]
-    batch_size = 6
-    num_workers = 4
-    num_epochs = 100
-    lambda_perc = 1.0
-    lambda_feat = 0.1
-    lambda_kld = 0.00001
-    loss_adv = 1.0
+net = SPADE_Net(
+    spatial_dims=2,
+    in_channels=1,
+    out_channels=1,
+    label_nc=6,
+    input_shape=input_shape,
+    num_channels=[16, 32, 64, 128],
+    z_dim=16,
+    is_vae=True,
+)
 
-    # ### Data
+# +
+discriminator = MultiScalePatchDiscriminator(
+    num_d=2,
+    num_layers_d=3,
+    spatial_dims=2,
+    num_channels=8,
+    in_channels=7,
+    out_channels=7,
+    minimum_size_im=128,
+    norm="INSTANCE",
+    kernel_size=3,
+)
 
-    # The data for this notebook comes from the public dataset OASIS (Open Access Series of Imaging Studies) [1]. The images have been registered to MNI space using ANTsPy, and then subsampled to 2mm isotropic resolution. Geodesic Information Flows (GIF) [2] has been used to segment 5 regions: cerebrospinal fluid (CSF), grey matter (GM), white matter (WM), deep grey matter (DGM) and brainstem. In addition, BaMos [3] has been used to provide white matter hyperintensities segmentations (WMH). The available dataset contains:
-    # - T1-weighted images
-    # - FLAIR weighted images
-    # - Segmentations with the following labels: 0 (background), 1 (CSF), 2 (GM), 3 (WM), 4 (DGM), 5 (brainstem) and 6 (WMH).
-    #
-    # _**Acknowledgments**: "Data were provided by OASIS-3: Longitudinal Multimodal Neuroimaging: Principal Investigators: T. Benzinger, D. Marcus, J. Morris; NIH P30 AG066444, P50 AG00561, P30 NS09857781, P01 AG026276, P01 AG003991, R01 AG043434, UL1 TR000448, R01 EB009352. AV-45 doses were provided by Avid Radiopharmaceuticals, a wholly owned subsidiary of Eli Lilly.”_
-    #
-    #
-    # Citations:
-    #
-    # [1] Marcus, DS, Wang, TH, Parker, J, Csernansky, JG, Morris, JC, Buckner. Open Access Series of Imaging Studies (OASIS): Cross-Sectional MRI Data in Young, Middle Aged, Nondemented, and Demented Older Adults, RL. Journal of Cognitive Neuroscience, 19, 1498-1507. doi: 10.1162/jocn.2007.19.9.1498
-    #
-    # [2] Cardoso MJ, Modat M, Wolz R, Melbourne A, Cash D, Rueckert D, Ourselin S. Geodesic Information Flows: Spatially-Variant Graphs and Their Application to Segmentation and Fusion. IEEE Trans Med Imaging. 2015 Sep;34(9):1976-88. doi: 10.1109/TMI.2015.2418298. Epub 2015 Apr 14. PMID: 25879909.
-    #
-    # [3] Fiford CM, Sudre CH, Pemberton H, Walsh P, Manning E, Malone IB, Nicholas J, Bouvy WH, Carmichael OT, Biessels GJ, Cardoso MJ, Barnes J; Alzheimer’s Disease Neuroimaging Initiative. Automated White Matter Hyperintensity Segmentation Using Bayesian Model Selection: Assessment and Correlations with Cognitive Change. Neuroinformatics. 2020 Jun;18(3):429-449. doi: 10.1007/s12021-019-09439-6. PMID: 32062817; PMCID: PMC7338814.
-    #
-    if not (root_dir / "data.zip").exists():
-        gdown.download(
-            "https://drive.google.com/uc?export=download&id=1SX_MCzQe-vyq09QYxECk32wZ2vxp9rx5", str(root_dir / "data.zip")
+adversarial_loss = PatchAdversarialLoss(reduction="sum", criterion="hinge")
+# -
+
+perceptual_loss = PerceptualLoss(spatial_dims=2, network_type="vgg", is_fake_3d=False, pretrained=True)
+perceptual_loss = perceptual_loss.to(device)
+
+optimizer_G = torch.optim.Adam(net.parameters(), lr=0.0002)
+optimizer_D = torch.optim.Adam(discriminator.parameters(), lr=0.0004)
+
+# ### Training loop
+#
+
+net = net.to(device)
+discriminator = discriminator.to(device)
+torch.autograd.set_detect_anomaly(True)
+losses = {"kld": [], "perceptual": [], "feature": [], "generator": [], "discriminator": []}
+losses_val = {"kld": [], "perceptual": [], "feature": [], "generator": [], "discriminator": []}
+for epoch in range(num_epochs):
+    print("Epoch %d/%d" % (epoch, num_epochs))
+    train_bar = tqdm(enumerate(train_loader), total=len(train_loader), ncols=120)
+    losses_epoch = {"kld": 0, "perceptual": 0, "feature": 0, "generator": 0, "discriminator": 0}
+    for step, d in train_bar:
+        image = d["image"].to(device)
+        with torch.no_grad():
+            label = one_hot(d["label"], 6).to(device)
+        optimizer_G.zero_grad()
+
+        # Losses gen
+        out, kld_loss = net(label, image)
+        disc_fakes, features_fakes = discriminator(torch.cat([out, label], 1))
+        loss_g = adversarial_loss(disc_fakes, target_is_real=True, for_discriminator=False)
+        disc_reals, features_reals = discriminator(torch.cat([image, label], 1))
+        loss_feat = feature_loss(features_fakes, features_reals, lambda_feat, device)
+        loss_perc = perceptual_loss(out, target=image)
+        total_loss = loss_g + loss_perc * lambda_perc + kld_loss * lambda_kld + loss_feat * lambda_feat
+        total_loss.backward(retain_graph=True)
+        optimizer_G.step()
+
+        # Store
+        losses_epoch["kld"] += kld_loss.item()
+        losses_epoch["perceptual"] += loss_perc.item()
+        losses_epoch["generator"] += loss_g.item()
+        # Train disc
+        out, _ = net(label, image)
+        disc_fakes, _ = discriminator(torch.cat([out, label], 1))
+        loss_d_r = adversarial_loss(disc_reals, target_is_real=True, for_discriminator=True)
+        loss_g_f = adversarial_loss(disc_fakes, target_is_real=False, for_discriminator=True)
+        optimizer_D.zero_grad()
+        loss_d = loss_d_r + loss_g_f
+        loss_d.backward()
+        optimizer_D.step()
+
+        # Store
+        losses_epoch["feature"] = loss_feat.item()
+        losses_epoch["discriminator"] = loss_d_r.item() + loss_g_f.item()
+
+        train_bar.set_postfix(
+            {
+                "kld": kld_loss.item(),
+                "perceptual": loss_perc.item(),
+                "generator": loss_g.item(),
+                "feature": loss_feat.item(),
+                "discriminator": loss_d_r.item() + loss_g_f.item(),
+            }
         )
-        zip_obj = zipfile.ZipFile(os.path.join(root_dir, "data.zip"), "r")
-        zip_obj.extractall(root_dir)
-    images_T1 = root_dir / "OASIS_SMALL-SUBSET/T1"
-    images_FLAIR = root_dir / "OASIS_SMALL-SUBSET/FLAIR"
-    labels = root_dir / "OASIS_SMALL-SUBSET/Segmentations"
 
-    # We create the data dictionaries that we need
-    all_images = [os.path.join(images_T1, i) for i in os.listdir(images_T1)] + [
-        os.path.join(images_FLAIR, i) for i in os.listdir(images_FLAIR)
-    ]
-    np.random.shuffle(all_images)
-    corresponding_labels = [
-        os.path.join(labels, os.path.basename(i).replace(os.path.basename(i).split("_")[0], "Parcellation")) for i in all_images
-    ]
-    input_dict = [{"image": i, "label": corresponding_labels[ind]} for ind, i in enumerate(all_images)]
-    input_dict_train = input_dict[: int(len(input_dict) * 0.9)]
-    input_dict_val = input_dict[int(len(input_dict) * 0.9) :]
-
-    # ### Dataloaders
-
-    # +
-    preliminar_shape = input_shape + [50]  # We take random slices fron the center of the brain
-    crop_shape = input_shape + [1]
-
-    base_transforms = [
-        monai.transforms.LoadImaged(keys=["label", "image"], image_only=False),
-        monai.transforms.EnsureChannelFirstd(keys=["image", "label"]),
-        monai.transforms.CenterSpatialCropd(keys=["label", "image"], roi_size=preliminar_shape),
-        monai.transforms.RandSpatialCropd(keys=["label", "image"], roi_size=crop_shape, max_roi_size=crop_shape, random_size=True),
-        monai.transforms.SqueezeDimd(keys=["label", "image"], dim=-1),
-        monai.transforms.Resized(keys=["image", "label"], spatial_size=input_shape),
-    ]
-    last_transforms = [
-        monai.transforms.CopyItemsd(keys=["label"], names=["label_channel"]),
-        monai.transforms.Lambdad(keys=["label_channel"], func=_masked_area),
-        monai.transforms.MaskIntensityd(keys=["image"], mask_key="label_channel"),
-        monai.transforms.NormalizeIntensityd(keys=["image"]),
-        monai.transforms.ToTensord(keys=["image", "label"]),
-    ]
-
-    aug_transforms = [
-        monai.transforms.RandBiasFieldd(coeff_range=(0, 0.005), prob=0.33, keys=["image"]),
-        monai.transforms.RandAdjustContrastd(gamma=(0.9, 1.15), prob=0.33, keys=["image"]),
-        monai.transforms.RandGaussianNoised(prob=0.33, mean=0.0, std=np.random.uniform(0.005, 0.015), keys=["image"]),
-        monai.transforms.RandAffined(
-            rotate_range=[-0.05, 0.05],
-            shear_range=[0.001, 0.05],
-            scale_range=[0, 0.05],
-            padding_mode="zeros",
-            mode="nearest",
-            prob=0.33,
-            keys=["label", "image"],
-        ),
-    ]
-
-    train_transforms = monai.transforms.Compose(base_transforms + aug_transforms + last_transforms)
-    val_transforms = monai.transforms.Compose(base_transforms + last_transforms)
-
-    train_dataset = monai.data.dataset.Dataset(input_dict_train, train_transforms)
-    val_dataset = monai.data.dataset.Dataset(input_dict_val, val_transforms)
-    train_loader = DataLoader(train_dataset, shuffle=True, batch_size=batch_size, num_workers=num_workers)
-    val_loader = DataLoader(val_dataset, shuffle=False, drop_last=False, batch_size=batch_size, num_workers=num_workers)
-
-
-    # -
-
-    # Sanity check
-    batch = next(iter(train_loader))
-    print(batch["image"].shape)
-    plt.subplot(1, 2, 1)
-    plt.imshow(batch["image"][0, 0, ...], cmap="gist_gray")
-    plt.axis("off")
-    plt.subplot(1, 2, 2)
-    plt.imshow(batch["label"][0, 0, ...], cmap="jet")
-    plt.axis("off")
-    plt.show()
-
-    # ### Network creation and losses
-
-    device = "cuda" if torch.cuda.is_available() else "cpu"
-
-    net = SPADENet(
-        spatial_dims=2,
-        in_channels=1,
-        out_channels=1,
-        label_nc=6,
-        input_shape=input_shape,
-        num_channels=[16, 32, 64, 128],
-        z_dim=16,
-        is_vae=True,
-    )
-
-    # +
-    discriminator = MultiScalePatchDiscriminator(
-        num_d=2,
-        num_layers_d=3,
-        spatial_dims=2,
-        num_channels=8,
-        in_channels=7,
-        out_channels=7,
-        minimum_size_im=128,
-        norm="INSTANCE",
-        kernel_size=3,
-    )
-
-    adversarial_loss = PatchAdversarialLoss(reduction="sum", criterion="hinge")
-    # -
-
-    perceptual_loss = PerceptualLoss(spatial_dims=2, network_type="vgg", is_fake_3d=False, pretrained=True)
-    perceptual_loss = perceptual_loss.to(device)
-
-    optimizer_G = torch.optim.Adam(net.parameters(), lr=0.0002)
-    optimizer_D = torch.optim.Adam(discriminator.parameters(), lr=0.0004)
-
-    # ### Training loop
-    #
-
-    net = net.to(device)
-    discriminator = discriminator.to(device)
-    torch.autograd.set_detect_anomaly(True)
-    losses = {"kld": [], "perceptual": [], "feature": [], "generator": [], "discriminator": []}
-    losses_val = {"kld": [], "perceptual": [], "feature": [], "generator": [], "discriminator": []}
-    for epoch in range(num_epochs):
-        print("Epoch %d/%d" % (epoch, num_epochs))
-        train_bar = tqdm(enumerate(train_loader), total=len(train_loader), ncols=120)
-        losses_epoch = {"kld": 0, "perceptual": 0, "feature": 0, "generator": 0, "discriminator": 0}
-        for step, d in train_bar:
-            image = d["image"].to(device)
-            with torch.no_grad():
-                label = one_hot(d["label"], 6).to(device)
-            optimizer_G.zero_grad()
-
+    val_bar = tqdm(enumerate(val_loader), total=len(val_loader), ncols=120)
+    losses_epoch_val = {"kld": 0, "perceptual": 0, "feature": 0, "generator": 0, "discriminator": 0}
+    for step, d in val_bar:
+        image = d["image"].to(device)
+        with torch.no_grad():
+            label = one_hot(d["label"], 6).to(device)
             # Losses gen
             out, kld_loss = net(label, image)
             disc_fakes, features_fakes = discriminator(torch.cat([out, label], 1))
@@ -265,29 +307,23 @@ def main():
             disc_reals, features_reals = discriminator(torch.cat([image, label], 1))
             loss_feat = feature_loss(features_fakes, features_reals, lambda_feat, device)
             loss_perc = perceptual_loss(out, target=image)
-            total_loss = loss_g + loss_perc * lambda_perc + kld_loss * lambda_kld + loss_feat * lambda_feat
-            total_loss.backward(retain_graph=True)
-            optimizer_G.step()
-
+            total_loss = loss_adv * loss_g + loss_perc * lambda_perc + kld_loss * lambda_kld + loss_feat * lambda_feat
             # Store
-            losses_epoch["kld"] += kld_loss.item()
-            losses_epoch["perceptual"] += loss_perc.item()
-            losses_epoch["generator"] += loss_g.item()
+            losses_epoch_val["kld"] += kld_loss.item()
+            losses_epoch_val["perceptual"] += loss_perc.item()
+            losses_epoch_val["generator"] += loss_g.item()
             # Train disc
             out, _ = net(label, image)
             disc_fakes, _ = discriminator(torch.cat([out, label], 1))
             loss_d_r = adversarial_loss(disc_reals, target_is_real=True, for_discriminator=True)
             loss_g_f = adversarial_loss(disc_fakes, target_is_real=False, for_discriminator=True)
-            optimizer_D.zero_grad()
-            loss_d = loss_d_r + loss_g_f
-            loss_d.backward()
-            optimizer_D.step()
+            loss_d = loss_adv * (loss_d_r + loss_g_f)
 
             # Store
-            losses_epoch["feature"] = loss_feat.item()
-            losses_epoch["discriminator"] = loss_d_r.item() + loss_g_f.item()
+            losses_epoch_val["feature"] = loss_feat.item()
+            losses_epoch_val["discriminator"] = loss_d_r.item() + loss_g_f.item()
 
-            train_bar.set_postfix(
+            val_bar.set_postfix(
                 {
                     "kld": kld_loss.item(),
                     "perceptual": loss_perc.item(),
@@ -296,71 +332,29 @@ def main():
                     "discriminator": loss_d_r.item() + loss_g_f.item(),
                 }
             )
-
-        val_bar = tqdm(enumerate(val_loader), total=len(val_loader), ncols=120)
-        losses_epoch_val = {"kld": 0, "perceptual": 0, "feature": 0, "generator": 0, "discriminator": 0}
-        for step, d in val_bar:
-            image = d["image"].to(device)
-            with torch.no_grad():
-                label = one_hot(d["label"], 6).to(device)
-                # Losses gen
-                out, kld_loss = net(label, image)
-                disc_fakes, features_fakes = discriminator(torch.cat([out, label], 1))
-                loss_g = adversarial_loss(disc_fakes, target_is_real=True, for_discriminator=False)
-                disc_reals, features_reals = discriminator(torch.cat([image, label], 1))
-                loss_feat = feature_loss(features_fakes, features_reals, lambda_feat, device)
-                loss_perc = perceptual_loss(out, target=image)
-                total_loss = loss_adv * loss_g + loss_perc * lambda_perc + kld_loss * lambda_kld + loss_feat * lambda_feat
-                # Store
-                losses_epoch_val["kld"] += kld_loss.item()
-                losses_epoch_val["perceptual"] += loss_perc.item()
-                losses_epoch_val["generator"] += loss_g.item()
-                # Train disc
-                out, _ = net(label, image)
-                disc_fakes, _ = discriminator(torch.cat([out, label], 1))
-                loss_d_r = adversarial_loss(disc_reals, target_is_real=True, for_discriminator=True)
-                loss_g_f = adversarial_loss(disc_fakes, target_is_real=False, for_discriminator=True)
-                loss_d = loss_adv * (loss_d_r + loss_g_f)
-
-                # Store
-                losses_epoch_val["feature"] = loss_feat.item()
-                losses_epoch_val["discriminator"] = loss_d_r.item() + loss_g_f.item()
-
-                val_bar.set_postfix(
-                    {
-                        "kld": kld_loss.item(),
-                        "perceptual": loss_perc.item(),
-                        "generator": loss_g.item(),
-                        "feature": loss_feat.item(),
-                        "discriminator": loss_d_r.item() + loss_g_f.item(),
-                    }
-                )
-                if step == 0 and epoch % 10 == 0:
-                    picture_results(label, image, out)
-        for key, val in losses_epoch.items():
-            losses[key].append(val / len(train_loader))
-        for key, val in losses_epoch_val.items():
-            losses_val[key].append(val / len(val_loader))
+            if step == 0 and epoch % 10 == 0:
+                picture_results(label, image, out)
+    for key, val in losses_epoch.items():
+        losses[key].append(val / len(train_loader))
+    for key, val in losses_epoch_val.items():
+        losses_val[key].append(val / len(val_loader))
 
 
-    # Plot losses
-    colors = ["orangered", "royalblue", "hotpink", "lime", "goldenrod"]
-    plt.figure(figsize=(5, 10))
-    ind = 0
-    for key, val in losses.items():
-        plt.subplot(len(losses.keys()), 1, ind + 1)
-        plt.plot(val, color=colors[ind], linestyle="-")
-        plt.plot(losses_val[key], color=colors[ind], linestyle="--")
-        plt.title(key)
-        plt.xlabel("Epochs")
-        ind += 1
-    plt.tight_layout()
-    plt.show()
+# Plot losses
+colors = ["orangered", "royalblue", "hotpink", "lime", "goldenrod"]
+plt.figure(figsize=(5, 10))
+ind = 0
+for key, val in losses.items():
+    plt.subplot(len(losses.keys()), 1, ind + 1)
+    plt.plot(val, color=colors[ind], linestyle="-")
+    plt.plot(losses_val[key], color=colors[ind], linestyle="--")
+    plt.title(key)
+    plt.xlabel("Epochs")
+    ind += 1
+plt.tight_layout()
+plt.show()
 
 # + [markdown] pycharm={"name": "#%%"}
 # **Conclusion**: from early on, the network shows the capability of discern between the different semantic layers. To achieve good image quality, more images and training time are needed (to avoid overfitting, seen in some loss plots of previous example), as well as thorough optimisation, such as establishing an adversarial schedule that makes sure that the discriminator and generator and the discriminator are trained only when their performance does not exceed a certain limit.
 #
 # -
-
-if __name__ == "__main__":
-    main()


### PR DESCRIPTION
Added features according to issue #475 leaving the default behaviour the same. According to my testing it should be as fast as the previous implementation.

Additionally, I fixed the 2D_spade_VAE.py tutorial, as it didn't work on my Windows laptop.