### PR TITLE
Allowed for the quantized flag to be passed to the LatentDiffusionInf…

### DIFF
--- a/generative/networks/nets/controlnet.py
+++ b/generative/networks/nets/controlnet.py
@@ -41,6 +41,7 @@ from torch import nn
 
 from generative.networks.nets.diffusion_model_unet import get_down_block, get_mid_block, get_timestep_embedding
 
+
 class ControlNetConditioningEmbedding(nn.Module):
     """
     Network to encode the conditioning into a latent space.
@@ -120,10 +121,9 @@ def zero_module(module):
         nn.init.zeros_(p)
     return module
 
-def copy_weights_to_controlnet(controlnet : nn.Module,
-                               diffusion_model: nn.Module,
-                               verbose: bool = True) -> None:
-    '''
+
+def copy_weights_to_controlnet(controlnet: nn.Module, diffusion_model: nn.Module, verbose: bool = True) -> None:
+    """
     Copy the state dict from the input diffusion model to the ControlNet, printing, if user requires it, the output
     keys that have matched and those that haven't.
 
@@ -131,15 +131,18 @@ def copy_weights_to_controlnet(controlnet : nn.Module,
         controlnet: instance of ControlNet
         diffusion_model: instance of DiffusionModelUnet or SPADEDiffusionModelUnet
         verbose: if True, the matched and unmatched keys will be printed.
-    '''
+    """
 
-    output = controlnet.load_state_dict(diffusion_model.state_dict(), strict = False)
+    output = controlnet.load_state_dict(diffusion_model.state_dict(), strict=False)
     if verbose:
         dm_keys = [p[0] for p in list(diffusion_model.named_parameters()) if p[0] not in output.unexpected_keys]
-        print(f"Copied weights from {len(dm_keys)} keys of the diffusion model into the ControlNet:"
-              f"\n{'; '.join(dm_keys)}\nControlNet missing keys: {len(output.missing_keys)}:"
-              f"\n{'; '.join(output.missing_keys)}\nDiffusion model incompatible keys: {len(output.unexpected_keys)}:"
-              f"\n{'; '.join(output.unexpected_keys)}")
+        print(
+            f"Copied weights from {len(dm_keys)} keys of the diffusion model into the ControlNet:"
+            f"\n{'; '.join(dm_keys)}\nControlNet missing keys: {len(output.missing_keys)}:"
+            f"\n{'; '.join(output.missing_keys)}\nDiffusion model incompatible keys: {len(output.unexpected_keys)}:"
+            f"\n{'; '.join(output.unexpected_keys)}"
+        )
+
 
 class ControlNet(nn.Module):
     """

--- a/tests/test_latent_diffusion_inferer.py
+++ b/tests/test_latent_diffusion_inferer.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import unittest
 
+import numpy as np
 import torch
 from parameterized import parameterized
 
@@ -329,6 +330,7 @@ class TestDiffusionSamplingInferer(unittest.TestCase):
                 seg=input_seg,
                 noise=noise,
                 timesteps=timesteps,
+                quantized=np.random.choice([True, False]),
             )
         else:
             prediction = inferer(
@@ -472,6 +474,7 @@ class TestDiffusionSamplingInferer(unittest.TestCase):
                 scheduler=scheduler,
                 save_intermediates=True,
                 seg=input_seg,
+                quantized=np.random.choice([True, False]),
             )
         else:
             sample, intermediates = inferer.get_likelihood(
@@ -480,6 +483,7 @@ class TestDiffusionSamplingInferer(unittest.TestCase):
                 diffusion_model=stage_2,
                 scheduler=scheduler,
                 save_intermediates=True,
+                quantized=np.random.choice([True, False]),
             )
         self.assertEqual(len(intermediates), 10)
         self.assertEqual(intermediates[0].shape, latent_shape)
@@ -525,6 +529,7 @@ class TestDiffusionSamplingInferer(unittest.TestCase):
                 save_intermediates=True,
                 resample_latent_likelihoods=True,
                 seg=input_seg,
+                quantized=np.random.choice([True, False]),
             )
         else:
             sample, intermediates = inferer.get_likelihood(
@@ -534,6 +539,7 @@ class TestDiffusionSamplingInferer(unittest.TestCase):
                 scheduler=scheduler,
                 save_intermediates=True,
                 resample_latent_likelihoods=True,
+                quantized=np.random.choice([True, False]),
             )
         self.assertEqual(len(intermediates), 10)
         self.assertEqual(intermediates[0].shape[2:], input_shape[2:])
@@ -590,6 +596,7 @@ class TestDiffusionSamplingInferer(unittest.TestCase):
                 condition=conditioning,
                 mode="concat",
                 seg=input_seg,
+                quantized=np.random.choice([True, False]),
             )
         else:
             prediction = inferer(
@@ -600,6 +607,7 @@ class TestDiffusionSamplingInferer(unittest.TestCase):
                 timesteps=timesteps,
                 condition=conditioning,
                 mode="concat",
+                quantized=np.random.choice([True, False]),
             )
         self.assertEqual(prediction.shape, latent_shape)
 
@@ -713,6 +721,7 @@ class TestDiffusionSamplingInferer(unittest.TestCase):
                 noise=noise,
                 timesteps=timesteps,
                 seg=input_seg,
+                quantized=np.random.choice([True, False]),
             )
         else:
             prediction = inferer(


### PR DESCRIPTION
…erer methods, which is then passed to VQVAE encode_stage_2_inputs if autoencoder_model is a VQVAE.

Set this flag randomly during testing (when the autoencoder is a VAE, it shouldn't matter), ran the tests, and ran reformatting.
+ controlnet.py has been changed for reformatting purposes only.